### PR TITLE
Remove Text.Parsec.Class.Orphans

### DIFF
--- a/parsec-class.cabal
+++ b/parsec-class.cabal
@@ -21,7 +21,6 @@ source-repository head
 
 library
   exposed-modules:  Text.Parsec.Class
-                    Text.Parsec.Class.Orphans
   hs-source-dirs:   src
   build-depends:    base >= 4.9 && < 5, parsec >= 3
   default-language: Haskell2010

--- a/src/Text/Parsec/Class.hs
+++ b/src/Text/Parsec/Class.hs
@@ -18,8 +18,6 @@ module Text.Parsec.Class
 
 import Prelude hiding ( fail )
 
-import Text.Parsec.Class.Orphans ( )   -- TODO: This is unnecessary.
-
 import Control.Exception ( throw )
 import Control.Monad.Fail
 import Data.Functor.Identity

--- a/src/Text/Parsec/Class/Orphans.hs
+++ b/src/Text/Parsec/Class/Orphans.hs
@@ -1,8 +1,0 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-
-module Text.Parsec.Class.Orphans where
-
-import Control.Exception
-import Text.Parsec.Error
-
-instance Exception ParseError


### PR DESCRIPTION
This is now defined in parsec 3.1.17.0.